### PR TITLE
Chore: update production assets compile to true

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"


### PR DESCRIPTION
### Description of changes
- Chore: update production assets compile to true
This is attempting to fix the ongoing issue deploying recent update to heroku with error "Precompiling Assets Failed"